### PR TITLE
fix daemonize for -f --foreground option

### DIFF
--- a/lib/app_perf_agent/cli.rb
+++ b/lib/app_perf_agent/cli.rb
@@ -70,7 +70,7 @@ module AppPerfAgent
         o.banner = "app_perf_agent [options]"
 
         o.on '-f', '--foreground', "Daemonize process" do |arg|
-          opts[:daemon] = false
+          opts[:daemon] = true
         end
 
         o.on '-l', '--license-key LICENSE_KEY', "License Key" do |arg|


### PR DESCRIPTION
agent doesn't start properly in daemon mode because of false daemon in default options and in -f option. Added true to daemon option.